### PR TITLE
limiting the number of suggestions

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -53,6 +53,8 @@ def upload_document(request):
     if len(request.FILES) != 1:
         raise ValueError('Only one file should be uploaded!')
 
+    max_suggestions = int(request.GET.get('limit', '-1'))
+    
     uploaded_file_key = list(request.FILES.keys())[0]
     file = request.FILES[uploaded_file_key]
 
@@ -70,7 +72,6 @@ def upload_document(request):
     else:
         raise ValueError('Document format not supported!')
 
-    max_suggestions = int(request.GET.get('limit', '-1'))
     content = generate_markings(text, max_suggestions)
 
     return JsonResponse(content)

--- a/api/views.py
+++ b/api/views.py
@@ -70,6 +70,7 @@ def upload_document(request):
     else:
         raise ValueError('Document format not supported!')
 
-    content = generate_markings(text)
+    max_suggestions = int(request.GET.get('limit', '-1'))
+    content = generate_markings(text, max_suggestions)
 
     return JsonResponse(content)


### PR DESCRIPTION
When uploading files there were no limits on the suggestions words as shown in the image below
![Capture](https://user-images.githubusercontent.com/37506005/179318567-02cab39d-8818-401d-b137-df2cd6101d08.PNG)

These are the results after the fix 
![Capture2](https://user-images.githubusercontent.com/37506005/179318659-bc02ab9d-18e3-4003-96bc-1fb2caf4ff11.PNG)


